### PR TITLE
Guid mod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "classnames": "^2.2.6"
+        "classnames": "^2.2.6",
+        "mendix-client": "^7.15.8"
       },
       "devDependencies": {
         "@mendix/pluggable-widgets-tools": "^8.12.0",
@@ -3516,6 +3517,11 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "node_modules/@types/dojo": {
+      "version": "1.9.44",
+      "resolved": "https://registry.npmjs.org/@types/dojo/-/dojo-1.9.44.tgz",
+      "integrity": "sha512-PXRBomRsnsKOntYqDmamJE9pJ95Bkcuynrvb46PHunClyek+AkuQQdF+MQpaUZUk/FhP+DQrleedtIWAfJe7Rg=="
     },
     "node_modules/@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -16891,6 +16897,20 @@
         "@types/react-native": "~0.61.0"
       }
     },
+    "node_modules/mendix-client": {
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/mendix-client/-/mendix-client-7.15.8.tgz",
+      "integrity": "sha512-RazCdCHoLVNKUUeKDkSkIL6Lxx6fUaa4iiy+Ltp9ra8mLQhwyNqD33TIN7YZJ3HDjHc3eWh9cjiZWwh6Jg/cQg==",
+      "dependencies": {
+        "@types/big.js": "0.0.31",
+        "@types/dojo": "^1.9.34"
+      }
+    },
+    "node_modules/mendix-client/node_modules/@types/big.js": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-0.0.31.tgz",
+      "integrity": "sha512-mXFtV8TyQRk6vUpRdIMgrv7/ZrzUaIcQPGB49wasb5jgg1o2HjFJ8fY957sbGrcUIYBKtpXNrPSUtv/ZNrvT4g=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -29369,6 +29389,11 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/dojo": {
+      "version": "1.9.44",
+      "resolved": "https://registry.npmjs.org/@types/dojo/-/dojo-1.9.44.tgz",
+      "integrity": "sha512-PXRBomRsnsKOntYqDmamJE9pJ95Bkcuynrvb46PHunClyek+AkuQQdF+MQpaUZUk/FhP+DQrleedtIWAfJe7Rg=="
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -39876,6 +39901,22 @@
         "@types/big.js": "^4.0.5",
         "@types/react": "~16.9.0",
         "@types/react-native": "~0.61.0"
+      }
+    },
+    "mendix-client": {
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/mendix-client/-/mendix-client-7.15.8.tgz",
+      "integrity": "sha512-RazCdCHoLVNKUUeKDkSkIL6Lxx6fUaa4iiy+Ltp9ra8mLQhwyNqD33TIN7YZJ3HDjHc3eWh9cjiZWwh6Jg/cQg==",
+      "requires": {
+        "@types/big.js": "0.0.31",
+        "@types/dojo": "^1.9.34"
+      },
+      "dependencies": {
+        "@types/big.js": {
+          "version": "0.0.31",
+          "resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-0.0.31.tgz",
+          "integrity": "sha512-mXFtV8TyQRk6vUpRdIMgrv7/ZrzUaIcQPGB49wasb5jgg1o2HjFJ8fY957sbGrcUIYBKtpXNrPSUtv/ZNrvT4g=="
+        }
       }
     },
     "merge-descriptors": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "copyright": "2020 BYU",
   "author": "Lauren Anderson",
   "config": {
-    "projectPath": "C:\\Users\\laurenra\\Documents\\Mendix\\HTML Audio-lauren-mod",
+    "projectPath": "",
     "mendixHost": "http://localhost:8080",
     "developmentPort": "3000"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "copyright": "2020 BYU",
   "author": "Lauren Anderson",
   "config": {
-    "projectPath": "",
+    "projectPath": "C:\\Users\\laurenra\\Documents\\Mendix\\HTML Audio-lauren-mod",
     "mendixHost": "http://localhost:8080",
     "developmentPort": "3000"
   },
@@ -29,6 +29,7 @@
     "@types/react-dom": "~16.9.0"
   },
   "dependencies": {
-    "classnames": "^2.2.6"
+    "classnames": "^2.2.6",
+    "mendix-client": "^7.15.8"
   }
 }

--- a/src/PlayAudioHTML.editorPreview.tsx
+++ b/src/PlayAudioHTML.editorPreview.tsx
@@ -1,13 +1,16 @@
 import { Component, ReactNode, createElement } from "react";
 import { PlayAudio } from "./components/PlayAudio";
 import { PlayAudioHTMLPreviewProps } from "../typings/PlayAudioHTMLProps";
+import { ListValue } from "mendix";
 
 declare function require(name: string): string;
 
 export class preview extends Component<PlayAudioHTMLPreviewProps> {
     render(): ReactNode {
-        const fileId = `[${this.props.fileId}]`;
-        return <PlayAudio fileId={fileId}/>;
+        // const fileId = `[${this.props.fileId}]`;
+        // return <PlayAudio
+        //     fileId={fileId}
+        return <PlayAudio/>;
     }
 }
 

--- a/src/PlayAudioHTML.tsx
+++ b/src/PlayAudioHTML.tsx
@@ -1,18 +1,17 @@
 import { Component, ReactNode, Fragment, createElement } from "react";
 
 import { PlayAudioHTMLContainerProps } from "../typings/PlayAudioHTMLProps";
-import {PlayAudio} from "./components/PlayAudio";
+import { PlayAudio } from "./components/PlayAudio";
 
 import "./ui/PlayAudioHTML.css";
 
 export default class PlayAudioHTML extends Component<PlayAudioHTMLContainerProps> {
     render(): ReactNode {
-        const fileId = this.props.fileId.displayValue;
         return <PlayAudio
-                fileId={fileId}
-                style={this.props.style}
                 className={this.props.class}
+                style={this.props.style}
                 tabIndex={this.props.tabIndex}
+                audioEntity={this.props.audioEntity}
                 />
     }
 }

--- a/src/PlayAudioHTML.xml
+++ b/src/PlayAudioHTML.xml
@@ -9,16 +9,10 @@
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">
-                <property key="fileId" type="attribute" required="true">
-                    <caption>FileID of FileDocument</caption>
-                    <description/>
-                    <attributeTypes>
-                        <attributeType name="String"/>
-                    </attributeTypes>
+                <property key="audioEntity" type="datasource" isList="true" required="true">
+                    <caption>Entity</caption>
+                    <description>Specialization of System.FileDocument for audio data. Use XPath constraint like [id=$currentObject] to return only currentObject in list.</description>
                 </property>
-            </propertyGroup>
-            <propertyGroup caption="Label">
-                <systemProperty key="Label" />
             </propertyGroup>
             <propertyGroup caption="Editability">
                 <systemProperty key="Editability"/>

--- a/src/components/PlayAudio.tsx
+++ b/src/components/PlayAudio.tsx
@@ -1,29 +1,65 @@
 import { CSSProperties, Component, ReactNode, createElement } from "react";
+import { ListValue } from "mendix";
 import classNames from "classnames";
 
 export interface PlayAudioProps {
-    fileId: string;
     className?: string;
-    index?: number;
     style?: CSSProperties;
     tabIndex?: number;
-    id?: string;
     hasError?: boolean;
     required?: boolean;
     disabled?: boolean;
+    audioEntity?: ListValue;
 }
 
 export class PlayAudio extends Component<PlayAudioProps> {
 
+    /**
+     * The src attribute of the HTML <audio> element is a URL for the audio file.
+     * Mendix stores audio in a specialization of System.FileDocument. The URL
+     * for the FileDocument is https://{hostname}:{port}/file?guid={file-guid}.
+     *
+     * For example:
+     *
+     * https://musicapp/file?guid=8725724278696207
+     * or
+     * https://localhost:8080/file?guid=8725724278773485
+     *
+     * NOTE: the audioEntity must return a list of ObjectItem of only one row
+     * with the currentObject. Use an XPath constraint in the widget Entity
+     * attribute in Studio Pro like [id=$currentObject] or
+     * [id='[%CurrentObject%]'] to constrain the list to just the currentObject.
+     */
+    // TODO: remove unused or unnecessary parameters like style, hasError, required, disbled.
     render(): ReactNode {
         const className = classNames(this.props.className);
-        const fileUrl = window.location.protocol + "//" +
+        const fileUrlRoot = window.location.protocol + "//" +
             window.location.hostname + ":" +
             window.location.port + "/" +
-            "file?guid=" + this.props.fileId;
-        return <div className="widget-play-audio">
-            <audio className="audio-player" controls src={fileUrl}>Your browser does not support the <code>audio</code> element.</audio>
-        </div>
+            "file?guid=";
+
+        if (this.props.audioEntity?.status === 'available') {
+            const ds = this.props.audioEntity;
+            var itemcount = 0;
+            var itemguid = "";
+            ds?.items?.forEach((dataItem) => {
+                itemcount++;
+                itemguid = dataItem.id;
+            });
+            if (itemcount === 1) {
+                return <div className={"outer-container"}>
+                    <div className="widget-play-audio">
+                        <audio className="audio-player" controls src={fileUrlRoot + itemguid}>Your browser does not support the <code>audio</code> element.</audio>
+                    </div>
+                </div>
+            }
+            else {
+                console.log('ERROR: Data source for Play Audio HTML widget must return a list of only one row with the current object. Try using [id=$currentObject] or similar in the XPath constraint to constrain to just the current object.');
+                return <div className={"outer-container"}>
+                    <p style={{"color": "red"}}>Error displaying Play Audio HTML widget.</p>
+                </div>
+            }
+        }
     }
 
 }

--- a/src/components/PlayAudio.tsx
+++ b/src/components/PlayAudio.tsx
@@ -29,6 +29,8 @@ export class PlayAudio extends Component<PlayAudioProps> {
      * with the currentObject. Use an XPath constraint in the widget Entity
      * attribute in Studio Pro like [id=$currentObject] or
      * [id='[%CurrentObject%]'] to constrain the list to just the currentObject.
+     *
+     * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
      */
     // TODO: remove unused or unnecessary parameters like style, hasError, required, disbled.
     render(): ReactNode {

--- a/src/ui/PlayAudioHTML.css
+++ b/src/ui/PlayAudioHTML.css
@@ -1,6 +1,10 @@
 /*
 Place your custom CSS here
 */
+.outer-container {
+    font-family: Arial,sans-serif;
+}
+
 .widget-play-audio {
     width: 304px;
     height: 24px;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "./node_modules/@mendix/pluggable-widgets-tools/configs/tsconfig.base.json",
   "compilerOptions": {
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "types": ["node", "mendix-client"],
+    "lib": ["es2017", "dom"]
   }
 }

--- a/typings/PlayAudioHTMLProps.d.ts
+++ b/typings/PlayAudioHTMLProps.d.ts
@@ -4,19 +4,18 @@
  * @author Mendix UI Content Team
  */
 import { CSSProperties } from "react";
-import { EditableValue } from "mendix";
+import { ListValue } from "mendix";
 
 export interface PlayAudioHTMLContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
     tabIndex?: number;
-    id: string;
-    fileId: EditableValue<string>;
+    audioEntity: ListValue;
 }
 
 export interface PlayAudioHTMLPreviewProps {
     class: string;
     style: string;
-    fileId: string;
+    audioEntity: {} | null;
 }


### PR DESCRIPTION
Mendix changed the URL parameters for FileDocuments. It uses the guid instead of the fileId now so the URL query parameter is "file?guid={guid}"; for example, https://mymusicapp/file?guid=8725724278773485. Modified code to get the guid from the datasource passed in to build the URL to pass in as the src attribute of the HTML <audio> element to play the audio file.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio